### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/rajesh0420/da358eef-547c-4a76-b916-b3004202466a/93ae4e15-51d9-4bf7-89d9-93a9e53f4252/_apis/work/boardbadge/1ad3a7ae-aadf-43a4-a59c-2f2f528cc820)](https://dev.azure.com/rajesh0420/da358eef-547c-4a76-b916-b3004202466a/_boards/board/t/93ae4e15-51d9-4bf7-89d9-93a9e53f4252/Microsoft.RequirementCategory)
 "# foxtrot" 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#6](https://dev.azure.com/rajesh0420/da358eef-547c-4a76-b916-b3004202466a/_workitems/edit/6). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.